### PR TITLE
Add pull requests body word average metric

### DIFF
--- a/repo-metrics.js
+++ b/repo-metrics.js
@@ -1,0 +1,22 @@
+var githubAPI = require('github')
+var _ = require('lodash')
+
+module.exports = {
+  /**
+  * Return the word average of the pull requests description
+  * @method getAverageWords
+  * @param {Array} pullRequests - Github API result
+  * @returns {Number}
+  */
+  getAverageWords: function(pullRequests) {
+    _.reduce(pullRequests, function(result, pr) {
+      return result + pr.body.split(' ').length
+    }, 0) / pullRequests.length
+  },
+
+  getAverageCommits: function(pullRequests) {
+  },
+
+  getAverageComments: function(pullRequests) {
+  }
+}


### PR DESCRIPTION
**Problem**
I want to be able to know the average of words per pull requests

**Solution**
A word is considered by anything separated by a whitespace:
`split(' ').length`

Use `lodash` to sum the word count with `reduce` and divide per pull
requests count to get the average.

**Result**
Can now use `getAverageWords` to calculate word average of pull requests
