### PR TITLE
Add cache system to limit API queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "github": "^0.2.4",
     "lodash": "^3.10.1",
-    "moment": "^2.10.6"
+    "moment": "^2.10.6",
+    "q": "^1.4.1"
   }
 }


### PR DESCRIPTION
**Problem** Loading pull requests from large github repository is slow every
time you call the `getPullRequests` function.

**Solution** Add cache system using `pullRequests.json` file stored under the
`data` folder for each repositories. The `refreshCache` method can be used to
clean the cache for a repository.

The `getPullRequests` method now returns a promise that resolve with the data.

**Result** Getting pull requests from a repository is now faster starting the
second time as data is being retrieved from the file system.
