### PR TITLE
Add get comments for pull requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+data/*


### PR DESCRIPTION
**Problem** The user can not get all the comments associated to pull requests

**Solution** Implement `getPullRequestsComments` which is doing N async
network calls to fetch all comments

Limitations:
- Can get only 100 comments maximum
- Only get file comments, not issue comments
- No cache strategy for comments

Remove `defaultConfig` object and review method interface to not have side.
Data is returned only from the promise result to save memory.

**Result** The module contains a `getPullRequestsComments` method to get all
pull requests comments.
