### PR TITLE
Add get commits for pull requests

### DIFF
--- a/repo-metrics.js
+++ b/repo-metrics.js
@@ -14,9 +14,27 @@ module.exports = {
     }, 0) / pullRequests.length
   },
 
+  /**
+  * Get average number of commits per pull requests
+  *
+  * @method getAverageCommits
+  * @param {Array} pullRequests - contains array of commits
+  * @return {Number}
+  */
   getAverageCommits: function(pullRequests) {
+    return _.reduce(pullRequests, function(sum, commits){
+      return sum + commits.length }, 0) / pullRequests.length
   },
 
+  /**
+  * Get average number of comments per pull requests
+  *
+  * @method getAverageComments
+  * @param {Array} pullRequests - contains array of comments
+  * @return {Number}
+  */
   getAverageComments: function(pullRequests) {
+    return _.reduce(pullRequests, function(sum, comments){
+      return sum + comments.length }, 0) / pullRequests.length
   }
 }


### PR DESCRIPTION
**Problem**
The user can not get all the commits associated to pull requests

**Solution**
Implement `getPullRequestsCommits` which is doing N async
network calls to fetch all commits

Limitations:
- Can get only 100 comments maximum
- No cache strategy for comments

Add method of `repo-metrics` to calculate average of comments and
commits per pull requests.

:bug: Fix caching issue with pull requests that did not remember auth
meta data

**Result** 
The module contains a `getPullRequestsCommits` method to get all
pull requests comments and can calculate the average or them.
