### PR TITLE
Cache and get pull requests details for Github org

### DIFF
--- a/modules/repo-github.js
+++ b/modules/repo-github.js
@@ -54,7 +54,6 @@ module.exports = {
 
     module.github.misc.rateLimit({}, function(error, data) {
       if (error) {
-        console.log('Error loading rate limit')
         deferred.reject(new Error(error))
       } else {
         deferred.resolve(data.rate)
@@ -86,7 +85,6 @@ module.exports = {
       per_page: 100
     }, function(error, data) {
       if (error) {
-        console.log('Error loading organization repositories')
         deferred.reject(new Error(error))
       } else {
         deferred.resolve(_.sortBy(data, function(repo) {
@@ -140,7 +138,6 @@ module.exports = {
         state: 'closed'
       }, function(error, data) {
         if (error) {
-          console.log('Error loading Pull requests')
           deferred.reject(new Error(error))
         } else {
           var filteredData = _.filter(data, function(pr) {
@@ -234,7 +231,6 @@ module.exports = {
     }, function(error, comments) {
       if (error) {
         deferred.reject(new Error(error))
-        console.log('Error loading Comments for Pull request #' + pullRequest.number)
       } else {
         delete comments.meta
         deferred.resolve(_.map(comments, function(comment) {

--- a/modules/repo-loader.js
+++ b/modules/repo-loader.js
@@ -11,6 +11,12 @@ var fs = require('fs')
 */
 module.exports = {
   /**
+  * Count of Github network queries to anticipate API rate limits
+  * @type {Number}
+  */
+  countQueries: 0,
+
+  /**
    * Remove all cached file for a given organization
    *
    * @method refreshCache
@@ -48,14 +54,148 @@ module.exports = {
   *
   * @method createCache
   * @public
+  * @param {String} organization
+  * @param {?Number} monthsHistory - optional
+  * @param {?String} rootPath - optional
   * @returns {Object} promise resolving to number of API queries done
   */
-  createCache: function(organization) {
-    // getOrganizationRepos
-    // getPullRequests
-    //  getPullRequestsCommits
-    //  getPullRequestsComments
-    //  cache PR
+  createCache: function(organization, monthsHistory, rootPath) {
+    var module = this
+    monthsHistory = monthsHistory || 3
+
+    // Create main cache folder
+    var cachePathOrg = (rootPath || 'cache') + '/' + organization
+    if (!fs.existsSync(cachePathOrg)) {
+      fs.mkdirSync(cachePathOrg)
+    }
+
+    // Process Organization
+    var organizationDeferred = Q.defer()
+    module.countQueries += 1
+    github.getOrganizationRepos(organization).then(function(repositories) {
+      module.processRepositories(repositories, organization, monthsHistory, cachePathOrg).then(function(result) {
+        organizationDeferred.resolve(result)
+      }).catch(function(error) { organizationDeferred.reject(new Error(error)) })
+    }).catch(function(error) { organizationDeferred.reject(new Error(error)) })
+
+    return organizationDeferred.promise
+  },
+
+  /**
+  * Get details of pull request from API for file system if exists
+  * @method getPullRequestDetails
+  * @private
+  * @param {Object} pullRequest
+  * @param {String} cachePathRepo
+  * @returns {Object} promise - resolved in pull request detail
+  */
+  getPullRequestDetails: function(pullRequest, cachePathRepo) {
+    var cachePathPR = cachePathRepo + '/pr_' + pullRequest.number + '.json'
+    var pullRequestDeferred = Q.defer()
+
+    // Get data from file system
+    if (fs.existsSync(cachePathPR)) {
+      fs.readFile(cachePathPR, 'utf8', function(error, data) {
+        var result
+        try {
+          result = JSON.parse(data)
+        } catch (error) {
+          fs.unlinkSync(cachePathPR) // Delete corrupted file
+          pullRequestDeferred.reject(new Error(error))
+        }
+
+        if (result) {
+          pullRequestDeferred.resolve(result)
+        }
+      })
+    } else { // Query Github API
+      var commitsDeferred = Q.defer()
+      var commentsDeferred = Q.defer()
+
+      module.countQueries += 1
+      github.getPullRequestCommits(pullRequest).then(function(commits) {
+        commitsDeferred.resolve(commits)
+      }).catch(function(error) { commitsDeferred.reject(new Error(error)) })
+
+      module.countQueries += 1
+      github.getPullRequestComments(pullRequest).then(function(comments) {
+        commentsDeferred.resolve(comments)
+      }).catch(function(error) { commentsDeferred.reject(new Error(error)) })
+
+      Q.all([
+        commitsDeferred.promise,
+        commentsDeferred.promise
+      ]).then(function(result) {
+        pullRequest.pull_request_commits = result[0]
+        pullRequest.pull_request_comments = result[1]
+        fs.writeFileSync(cachePathPR, JSON.stringify(pullRequest, false, 2))
+        pullRequestDeferred.resolve(pullRequest)
+      }).catch(function(error) { pullRequestDeferred.reject(new Error(error)) })
+    }
+
+    return pullRequestDeferred.promise
+  },
+
+  /**
+  * @method processRepositories
+  * @private
+  * @param {Array} repositories
+  * @param {String} organization
+  * @param {Number} monthsHistory
+  * @param {String} cachePathOrg
+  * @return {Object} promise - resolves to array of pull requests details
+  */
+  processRepositories: function(repositories, organization, monthsHistory, cachePathOrg) {
+    var repositoryPromises = []
+    var module = this
+
+    _.forEach(repositories, function(repository) {
+      var repositoryDeferred = Q.defer()
+      var cachePathRepo = cachePathOrg + '/' + repository.name
+
+      if (!fs.existsSync(cachePathRepo)) {
+        fs.mkdirSync(cachePathRepo)
+      }
+
+      // Process repository
+      github.getPullRequests(organization, repository.name,
+      monthsHistory).then(function(pullRequests) {
+        module.countQueries += pullRequests.length/100
+        module.processPullRequests(pullRequests, cachePathRepo).then(function(result) {
+          repositoryDeferred.resolve({
+            repository: repository,
+            pull_requests: result
+          })
+        }).catch(function(error) { repositoryDeferred.reject(new Error(error)) })
+      }).catch(function(error) { repositoryDeferred.reject(new Error(error)) })
+
+      repositoryPromises.push(repositoryDeferred.promise)
+    })
+
+    return Q.all(repositoryPromises)
+  },
+
+  /**
+  * @method processPullRequests
+  * @private
+  * @param {Array} pullRequests
+  * @param {String} cachePathRepo
+  * @return {Object} promise - resolves to array of pull request details
+  */
+  processPullRequests: function(pullRequests, cachePathRepo) {
+    var module = this
+    var pullRequestPromises = []
+
+    _.forEach(pullRequests, function(pullRequest) {
+      var pullRequestDetailsDeferred = Q.defer()
+      module.getPullRequestDetails(pullRequest, cachePathRepo).then(function(pullRequestDetails) {
+        pullRequestDetailsDeferred.resolve(pullRequestDetails)
+      }).catch(function(error) { pullRequestDetailsDeferred.reject(new Error(error)) })
+
+      pullRequestPromises.push(pullRequestDetailsDeferred.promise)
+    })
+
+    return Q.all(pullRequestPromises)
   },
 
   /**


### PR DESCRIPTION
**Problem** Not possible get all pull requests detailed information for all
repositories of an organization and cache it on the file system.

**Solution** Implement a function `createCache` that query all organization
repositories to get pull requests details (including commits and comments) and
cache it on the file system.

The cache system is one file per pull requests. When doing a query to
`createCache` all pull requests are checked to see if they exist on dist.

**Result** Use the function `createCache` which return a promise with all pull
requests details.
